### PR TITLE
Fixes modification of polygon in `closest`

### DIFF
--- a/dist/leaflet.geometryutil.js
+++ b/dist/leaflet.geometryutil.js
@@ -112,7 +112,7 @@ L.GeometryUtil = L.extend(L.GeometryUtil || {}, {
         if (typeof layer.getLatLngs != 'function')
             layer = L.polyline(layer);
 
-        var latlngs = layer.getLatLngs(),
+        var latlngs = layer.getLatLngs().slice(0),
             mindist = Infinity,
             result = null,
             i, n, distance;


### PR DESCRIPTION
Calling the `closest` function was causing Polygons to gain extra vertices on every call because of `latlngs.push(latlngs[0]);` on line 135. As a consequence, the polygons grow enormously when using the Leaflet.Snap library.

This change makes the `closest` function instead clone the layer's array of latlngs so that there are no side effects.
