### PR TITLE
Make sure that interpolateOnLine always returns a LatLng object.

### DIFF
--- a/dist/leaflet.geometryutil.js
+++ b/dist/leaflet.geometryutil.js
@@ -284,12 +284,16 @@ L.GeometryUtil = L.extend(L.GeometryUtil || {}, {
         }
 
         if (ratio === 0) {
-            return {latLng: latLngs[0],
-                    predecessor: -1};
+            return {
+                latLng: latLngs[0] instanceof L.LatLng ? latLngs[0] : L.latLng(latLngs[0]),
+                predecessor: -1
+            };
         }
         if (ratio == 1) {
-            return {latLng: latLngs[latLngs.length -1],
-                    predecessor: latLngs.length-2};
+            return {
+                latLng: latLngs[latLngs.length -1] instanceof L.LatLng ? latLngs[latLngs.length -1] : L.latLng(latLngs[latLngs.length -1]),
+                predecessor: latLngs.length - 2
+            };
         }
 
         // ensure the ratio is between 0 and 1;

--- a/test/test.geometryutil.js
+++ b/test/test.geometryutil.js
@@ -321,6 +321,16 @@ describe('Interpolate on line', function() {
     assert.deepEqual(withArray, withPolyLine);
     done();
   });
+
+  it('Should always return a LatLng object.', function() {
+    var interp1 = L.GeometryUtil.interpolateOnLine(map, [llA, llB, llC], 0);
+    var interp2 = L.GeometryUtil.interpolateOnLine(map, [llA, llB, llC], 1);
+
+    assert.isDefined(interp1.latLng.lat);
+    assert.isDefined(interp1.latLng.lng);
+    assert.isDefined(interp2.latLng.lat);
+    assert.isDefined(interp2.latLng.lng);
+  });
 });
 
 


### PR DESCRIPTION
The signature of interpolateOnLine declares that it will return an object structured like so: { latLng: {{LatLng}}, predecessor: {{int}} }.  That is, the latLng property of interpolateOnLine should be a LatLng object.  When the ratio is 0 (or 1), interpolateOnLine just returned the first (or last, respectively) element of the array of coordinates.

This is fine if the polyline is supplied as an array of LatLng objects - but the type signature of interpolateOnLine says that it also takes an array of [lat, lng] arrays.  If an array of [lat, lng] arrays is supplied, the interpolateOnLine returns a flat [lat, lng] array on ratio = 0 or 1, NOT a LatLng object.

I added a check for the type of the first and last coordinates.  If they are LatLng objects, they are returned immediately.  If they are not LatLng objects, then a LatLng object with the same coordinates is returned.

This ensures that the return value of interpolateOnLine is consistent, since for values in the open interval (0,1) it ALWAYS already returns a LatLng object, not a [lat, lng] array.

I added a test verifying the presence of this bug.  With my code changes, this test is satisfied.
