### PR TITLE
Soft leaflet dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "make test"
   }
   , "dependencies": {
-    "leaflet": "0.7.0"
+    "leaflet": "^0.7.0"
   }
   , "devDependencies": {
     "mocha": "1.9.0",


### PR DESCRIPTION
Hello,

Using browserify and mapbox.js, Leaflet is required twice (which makes it impossible to use mapbox because window.L is redefined) .
Using a soft dependency resolves that.

Cheers
Erik
