### PR TITLE
Ensure the ratio is between 0 and 1 *before* any tests

### DIFF
--- a/dist/leaflet.geometryutil.js
+++ b/dist/leaflet.geometryutil.js
@@ -283,6 +283,9 @@ L.GeometryUtil = L.extend(L.GeometryUtil || {}, {
             return null;
         }
 
+        // ensure the ratio is between 0 and 1;
+        ratio = Math.max(Math.min(ratio, 1), 0);
+
         if (ratio === 0) {
             return {
                 latLng: latLngs[0] instanceof L.LatLng ? latLngs[0] : L.latLng(latLngs[0]),
@@ -295,9 +298,6 @@ L.GeometryUtil = L.extend(L.GeometryUtil || {}, {
                 predecessor: latLngs.length - 2
             };
         }
-
-        // ensure the ratio is between 0 and 1;
-        ratio = Math.max(Math.min(ratio, 1), 0);
 
         // project the LatLngs as Points,
         // and compute total planar length of the line at max precision

--- a/test/test.geometryutil.js
+++ b/test/test.geometryutil.js
@@ -285,6 +285,7 @@ describe('Interpolate on line', function() {
     assert.equal(null, L.GeometryUtil.interpolateOnLine(map, [llA], 0.5));
     done();
   });
+  
 
   it('It should be the first vertex if offset is 0', function(done) {
     var interp = L.GeometryUtil.interpolateOnLine(map, [llA, llB], 0);
@@ -293,8 +294,22 @@ describe('Interpolate on line', function() {
     done();
   });
 
+  it('It should be the first vertex if offset is less than 0', function(done) {
+    var interp = L.GeometryUtil.interpolateOnLine(map, [llA, llB], -10);
+    assert.latLngEqual(interp.latLng, llA);
+    assert.equal(interp.predecessor, -1);
+    done();
+  });
+
   it('It should be the last vertex if offset is 1', function(done) {
     var interp = L.GeometryUtil.interpolateOnLine(map, [llA, llB, llC], 1);
+    assert.latLngEqual(interp.latLng, llC);
+    assert.equal(interp.predecessor, 1);
+    done();
+  });
+
+  it('It should be the last vertex if offset is more than 1', function(done) {
+    var interp = L.GeometryUtil.interpolateOnLine(map, [llA, llB, llC], 10);
     assert.latLngEqual(interp.latLng, llC);
     assert.equal(interp.predecessor, 1);
     done();


### PR DESCRIPTION
In the interpolateOnLine, the ratio limitations should be done *before* any tests.