### PR TITLE
add function layersWithin()

### DIFF
--- a/dist/leaflet.geometryutil.js
+++ b/dist/leaflet.geometryutil.js
@@ -257,7 +257,11 @@ L.GeometryUtil = L.extend(L.GeometryUtil || {}, {
         }
       }
 
-      return results;
+      var sortedResults = results.sort(function(a, b) {
+          return a.distance - b.distance;
+      });
+
+      return sortedResults;
     },
 
     /**

--- a/dist/leaflet.geometryutil.js
+++ b/dist/leaflet.geometryutil.js
@@ -226,7 +226,7 @@ L.GeometryUtil = L.extend(L.GeometryUtil || {}, {
     },
 
     /**
-     * Returns all layers within a radius of the given position.
+     * Returns all layers within a radius of the given position, in an ascending order of distance.
        @param {L.Map} map
        @param {Array<ILayer>} layers - A list of layers.
        @param {L.LatLng} latlng - The position to search.

--- a/dist/leaflet.geometryutil.js
+++ b/dist/leaflet.geometryutil.js
@@ -228,7 +228,7 @@ L.GeometryUtil = L.extend(L.GeometryUtil || {}, {
     /**
      * Returns all layers within a radius of the given position.
        @param {L.Map} map
-       @param {Array<ILayer>} layers - A list of layers to snap on.
+       @param {Array<ILayer>} layers - A list of layers.
        @param {L.LatLng} latlng - The position to search.
        @param {?Number} [radius=Infinity] - Search radius in pixels
        @return {object[]} an array of object including layer within the radius, closest latlng, and distance

--- a/dist/leaflet.geometryutil.js
+++ b/dist/leaflet.geometryutil.js
@@ -226,6 +226,41 @@ L.GeometryUtil = L.extend(L.GeometryUtil || {}, {
     },
 
     /**
+     * Returns all layers within a radius of the given position.
+       @param {L.Map} map
+       @param {Array<ILayer>} layers - A list of layers to snap on.
+       @param {L.LatLng} latlng - The position to search.
+       @param {?Number} [radius=Infinity] - Search radius in pixels
+       @return {object[]} an array of object including layer within the radius, closest latlng, and distance
+     */
+    layersWithin: function(map, layers, latlng, radius) {
+      radius = typeof radius == 'number' ? radius : Infinity;
+
+      var results = [];
+      var ll = null;
+      var distance = 0;
+
+      for (var i = 0, n = layers.length; i < n; i++) {
+        var layer = layers[i];
+
+        if (typeof layer.getLatLng == 'function') {
+            ll = layer.getLatLng();
+            distance = L.GeometryUtil.distance(map, latlng, ll);
+        }
+        else {
+            ll = L.GeometryUtil.closest(map, layer, latlng);
+            if (ll) distance = ll.distance;  // Can return null if layer has no points.
+        }
+
+        if (ll && distance < radius) {
+            results.push({layer: layer, latlng: ll, distance: distance});
+        }
+      }
+
+      return results;
+    },
+
+    /**
         Returns the closest position from specified {LatLng} among specified layers,
         with a maximum tolerance in pixels, providing snapping behaviour.
         @param {L.Map} map
@@ -501,7 +536,7 @@ L.GeometryUtil = L.extend(L.GeometryUtil || {}, {
 
     /**
        Returns the bearing in degrees clockwise from north (0 degrees)
-       from the first L.LatLng to the second, at the first LatLng 
+       from the first L.LatLng to the second, at the first LatLng
        @param {L.LatLng} latlng1: origin point of the bearing
        @param {L.LatLng} latlng2: destination point of the bearing
        @returns {float} degrees clockwise from north.

--- a/test/test.geometryutil.js
+++ b/test/test.geometryutil.js
@@ -214,7 +214,7 @@ describe('Layers within a radius of the given location', function() {
     done();
   });
 
-  it('It should return an array containing two layer ordered by distance', function(done) {
+  it('It should return an array containing two layers ordered by distance', function(done) {
     var ll = L.latLng([0, 0]);
     var layers = [L.marker([2, 2]), L.marker([3, 3])];
     var results = L.GeometryUtil.layersWithin(map, layers, ll, 10);

--- a/test/test.geometryutil.js
+++ b/test/test.geometryutil.js
@@ -213,6 +213,15 @@ describe('Layers within a radius of the given location', function() {
     assert.deepEqual(results[0], {layer: layers[0], latlng: layers[0].getLatLng(), distance: Math.sqrt(2)});
     done();
   });
+
+  it('It should return an array containing two layer ordered by distance', function(done) {
+    var ll = L.latLng([0, 0]);
+    var layers = [L.marker([2, 2]), L.marker([3, 3])];
+    var results = L.GeometryUtil.layersWithin(map, layers, ll, 10);
+    assert.equal(2, results.length);
+    assert.equal(true, results[0].distance < results[1].distance);
+    done();
+  });
 });
 
 

--- a/test/test.geometryutil.js
+++ b/test/test.geometryutil.js
@@ -197,6 +197,24 @@ describe('Closest among layers', function() {
   });
 });
 
+describe('Layers within a radius of the given location', function() {
+  it('It should return an empty array if the list is empty', function(done) {
+    var ll = L.latLng([0, 0]);
+    var results = L.GeometryUtil.layersWithin(map, [], ll);
+    assert.equal(0, results.length);
+    done();
+  });
+
+  it('It should return an array containing one layer', function(done) {
+    var ll = L.latLng([0, 0]);
+    var layers = [L.marker([2, 2]), L.marker([100, 100])];
+    var results = L.GeometryUtil.layersWithin(map, layers, ll, 5);
+    assert.equal(1, results.length);
+    assert.deepEqual(results[0], {layer: layers[0], latlng: layers[0].getLatLng(), distance: Math.sqrt(2)});
+    done();
+  });
+});
+
 
 describe('Closest snap', function() {
   var square, diagonal, d, w, layers;
@@ -285,7 +303,7 @@ describe('Interpolate on line', function() {
     assert.equal(null, L.GeometryUtil.interpolateOnLine(map, [llA], 0.5));
     done();
   });
-  
+
 
   it('It should be the first vertex if offset is 0', function(done) {
     var interp = L.GeometryUtil.interpolateOnLine(map, [llA, llB], 0);


### PR DESCRIPTION
`layersWithin()` function is similar to the `closestLayer()`. The difference is that `layersWithin()` accepts an additional parameter `radius` to search the nearby layers. It returns an array of objects, each of which includes the layer within in the radius, the closest latlng, and the distance. The `closestLayer()` is a special case of `layersWithin()` that only returns the first result (if any) in the array.