### PR TITLE
concatenate polylines

### DIFF
--- a/dist/leaflet.geometryutil.js
+++ b/dist/leaflet.geometryutil.js
@@ -498,76 +498,6 @@ L.GeometryUtil = L.extend(L.GeometryUtil || {}, {
     },
 
     /**
-     * Concatenate polylines in two line groups
-     * @param  {L.Map}        map
-     * @param  {L.Polyline[]} lineGroupA        An array of L.Polyline objects
-     * @param  {L.Polyline[]} lineGroupB        An array of L.Polyline objects
-     * @param  {Number}       tolerance         A pixel distance in which points will be considered equal
-     * @param  {Function}     [onEachConcat]    A function called at each Concatenation. It accepts two parameters:
-     *                                          dest (line to be concatenated) and src (line to concatenate).
-     * @return {L.Polyline[]} concateLines      An array of concatenated L.Polyline objects
-     */
-    _concatLineGroups: function(map, lineGroupA, lineGroupB, tolerance, onEachConcat) {
-
-        var ll, lr;
-
-        for (var i = 0, n = lineGroupA.length; i < n; i++) {
-
-            ll = lineGroupA[i].getLatLngs();
-
-            for (var j = 0, m = lineGroupB.length; j < m; j++) {
-
-                // if the right line has been merged, skip it
-                if (lineGroupB[j].merged) { continue; }
-
-                lr = lineGroupB[j].getLatLngs();
-
-                // if the right line starts at the start of the left line
-                if (L.GeometryUtil.distance(map, ll[0], lr[0]) < tolerance) {
-                    lr.splice(0, 1);
-                    lineGroupA[i].spliceLatLngs.apply(lineGroupA[i], [0, 0].concat(lr.reverse()));
-                    lineGroupB[j].merged = true;
-                    if (onEachConcat) { onEachConcat(lineGroupA[i], lineGroupB[j]); }
-                    continue;
-                }
-
-                // if the right line ends at the start of the left line
-                if (L.GeometryUtil.distance(map, ll[0], lr[lr.length - 1]) < tolerance) {
-                    lr.splice(lr.length - 1, 1);
-                    lineGroupA[i].spliceLatLngs.apply(lineGroupA[i], [0, 0].concat(lr));
-                    lineGroupB[j].merged = true;
-                    if (onEachConcat) { onEachConcat(lineGroupA[i], lineGroupB[j]); }
-                    continue;
-                }
-
-                // if the right line starts at the end of the left line
-                if (L.GeometryUtil.distance(map, ll[ll.length - 1], lr[0]) < tolerance) {
-                    lr.splice(0, 1);
-                    lineGroupA[i].spliceLatLngs.apply(lineGroupA[i], [ll.length, 0].concat(lr));
-                    lineGroupB[j].merged = true;
-                    if (onEachConcat) { onEachConcat(lineGroupA[i], lineGroupB[j]); }
-                    continue;
-                }
-
-                // if the right line ends at the end of the left line
-                if (L.GeometryUtil.distance(map, ll[ll.length - 1], lr[lr.length - 1]) < tolerance) {
-                    lr.splice(lr.length - 1, 1);
-                    lineGroupA[i].spliceLatLngs.apply(lineGroupA[i], [ll.length, 0].concat(lr.reverse()));
-                    lineGroupB[j].merged = true;
-                    if (onEachConcat) { onEachConcat(lineGroupA[i], lineGroupB[j]); }
-                    continue;
-                }
-            }
-        }
-
-        var unmerged = lineGroupB.filter(function(polyline) {
-            return !polyline.merged;
-        });
-
-        return lineGroupA.concat(unmerged);
-    },
-
-    /**
      * Concatenate polylines whose start/end points are within a close distance
      * @param  {L.Map}        map
      * @param  {L.Polyline[]} polylines         An array of L.Polyline objects
@@ -583,11 +513,60 @@ L.GeometryUtil = L.extend(L.GeometryUtil || {}, {
         tolerance = typeof tolerance == 'number' ? tolerance : 15;
         onEachConcat = typeof onEachConcat == 'function' ? onEachConcat : undefined;
 
-        var middle = polylines.length >> 1;
-        var lls = L.GeometryUtil.concatLines(map, polylines.slice(0, middle), tolerance);
-        var lrs = L.GeometryUtil.concatLines(map, polylines.slice(middle, polylines.length), tolerance);
+        var ll, lr;
 
-        return L.GeometryUtil._concatLineGroups(map, lls, lrs, tolerance, onEachConcat);
+        for (var i = 0, n = polylines.length; i < n; i++) {
+
+            if (polylines[i].merged) { continue; }
+
+            ll = polylines[i].getLatLngs();
+
+            for (var j = 0, m = polylines.length; j < m; j++) {
+
+                // if the right line has been merged, skip it
+                if (polylines[j].merged || i === j) { continue; }
+
+                lr = polylines[j].getLatLngs();
+
+                // if the right line starts at the start of the left line
+                if (L.GeometryUtil.distance(map, ll[0], lr[0]) < tolerance) {
+                    lr.splice(0, 1);
+                    polylines[i].spliceLatLngs.apply(polylines[i], [0, 0].concat(lr.reverse()));
+                    polylines[j].merged = true;
+                    if (onEachConcat) { onEachConcat(polylines[i], polylines[j]); }
+                    continue;
+                }
+
+                // if the right line ends at the start of the left line
+                if (L.GeometryUtil.distance(map, ll[0], lr[lr.length - 1]) < tolerance) {
+                    lr.splice(lr.length - 1, 1);
+                    polylines[i].spliceLatLngs.apply(polylines[i], [0, 0].concat(lr));
+                    polylines[j].merged = true;
+                    if (onEachConcat) { onEachConcat(polylines[i], polylines[j]); }
+                    continue;
+                }
+
+                // if the right line starts at the end of the left line
+                if (L.GeometryUtil.distance(map, ll[ll.length - 1], lr[0]) < tolerance) {
+                    lr.splice(0, 1);
+                    polylines[i].spliceLatLngs.apply(polylines[i], [ll.length, 0].concat(lr));
+                    polylines[j].merged = true;
+                    if (onEachConcat) { onEachConcat(polylines[i], polylines[j]); }
+                    continue;
+                }
+
+                // if the right line ends at the end of the left line
+                if (L.GeometryUtil.distance(map, ll[ll.length - 1], lr[lr.length - 1]) < tolerance) {
+                    lr.splice(lr.length - 1, 1);
+                    polylines[i].spliceLatLngs.apply(polylines[i], [ll.length, 0].concat(lr.reverse()));
+                    polylines[j].merged = true;
+                    if (onEachConcat) { onEachConcat(polylines[i], polylines[j]); }
+                    continue;
+                }
+            }
+        }
+
+        return polylines.filter(function(polyline) { return !polyline.merged; });
     },
 
     /**

--- a/dist/leaflet.geometryutil.js
+++ b/dist/leaflet.geometryutil.js
@@ -504,12 +504,11 @@ L.GeometryUtil = L.extend(L.GeometryUtil || {}, {
      * @param  {Number}       [tolerance=15]    A pixel distance in which points will be considered equal
      * @return {L.Polyline[]} concateLines      An array of concatenated L.Polyline objects
      */
-    concatLines: function(map, polylines, tolerance, onEachConcat) {
+    concatLines: function(map, polylines, tolerance) {
 
         if (polylines.length < 2) { return polylines; }
 
         tolerance = typeof tolerance == 'number' ? tolerance : 15;
-        onEachConcat = typeof onEachConcat == 'function' ? onEachConcat : undefined;
 
         // clone layers
         var clonedLayers = []

--- a/test/test.geometryutil.js
+++ b/test/test.geometryutil.js
@@ -1,3 +1,12 @@
+/**
+* @Author: haoliang
+* @Date:   2016-04-25T21:42:21-04:00
+* @Last modified by:   haoliang
+* @Last modified time: 2016-04-25T21:52:14-04:00
+*/
+
+
+
 var assert = chai.assert;
 
 

--- a/test/test.geometryutil.js
+++ b/test/test.geometryutil.js
@@ -477,6 +477,53 @@ describe('Line order', function() {
   });
 });
 
+describe('Concatenate polylines', function(done) {
+
+  it('It should return an empty array if no polyline is given', function(done) {
+    var concated = L.GeometryUtil.concatLines(map, []);
+    assert.equal(concated.length, 0);
+    done();
+  });
+
+  it('It should return the original array if there is one given polyline', function(done) {
+    var line = L.polyline([[0, 0], [1, 1]]);
+    var concated = L.GeometryUtil.concatLines(map, [line]);
+    assert.equal(concated.length, 1);
+    done();
+  });
+
+  it('It should return an arry of concatenated lines', function(done) {
+    var lineA = L.polyline([[0, 0], [1, 1]]);
+    var lineB = L.polyline([[0.1, 0.1], [2, 1]]);
+    var lineC = L.polyline([[20, 20], [30, 30]]);
+    var lineD = L.polyline([[35, 35], [40, 40], [30, 30]]);
+    var concated = L.GeometryUtil.concatLines(map, [lineD, lineA, lineC, lineB], 1);
+
+    assert.equal(concated.length, 2);
+
+    var concatedLatLngs = concated[0].getLatLngs();
+    assert.equal(concatedLatLngs.length, 4);
+    assert.isTrue(concatedLatLngs[0].equals(L.latLng([35, 35])));
+    assert.isTrue(concatedLatLngs[3].equals(L.latLng([20, 20])));
+
+    var concatedLatLngs = concated[1].getLatLngs();
+    assert.equal(concatedLatLngs.length, 3);
+    assert.isTrue(concatedLatLngs[0].equals(L.latLng([2, 1])));
+    assert.isTrue(concatedLatLngs[2].equals(L.latLng([1, 1])));
+
+    done();
+  })
+
+  it('It should return an array of all polylines if none of them can be concatenated', function(done) {
+    var lineA = L.polyline([[0, 0], [1, 1]]);
+    var lineB = L.polyline([[100, 100], [200, 200]]);
+    var concated = L.GeometryUtil.concatLines(map, [lineA, lineB]);
+
+    assert.equal(concated.length, 2);
+    done();
+  });
+});
+
 describe('Compute angle', function() {
   it('It should return angle', function(done) {
     var p1 = L.point(0, 0),

--- a/test/test.geometryutil.js
+++ b/test/test.geometryutil.js
@@ -1,12 +1,3 @@
-/**
-* @Author: haoliang
-* @Date:   2016-04-25T21:42:21-04:00
-* @Last modified by:   haoliang
-* @Last modified time: 2016-04-25T21:52:14-04:00
-*/
-
-
-
 var assert = chai.assert;
 
 


### PR DESCRIPTION
This function concatenates polylines if their start/end points are within the specific tolerance. It's not equal to #5 since the function doesn't care about any intermediate vertices, no matter how close they are. The primary use case of this function is to rebuild a complete polyline from an array of line segments.The output is an array in case some polylines are unable to be concatenated into the other.

It works well in my use case and I have designed some test cases for it. Not sure whether they covers all cases, so please let me know if I can make improvement.
