### PR TITLE
Closest with last segment

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -30,6 +30,11 @@
         return assert.equal(Math.round(a * Math.pow(10, n)) / Math.pow(10, n),
                             Math.round(b * Math.pow(10, n)) / Math.pow(10, n));
     };
+    assert.almostNotEqual = function (a, b, n) {
+        n = n || 12;
+        return assert.notEqual(Math.round(a * Math.pow(10, n)) / Math.pow(10, n),
+                            Math.round(b * Math.pow(10, n)) / Math.pow(10, n));
+    };
     // use Leaflet equality functions for Point and LatLng
     assert.pointEqual = function (a, b) {
         return a.equals(b);

--- a/spec/index.html
+++ b/spec/index.html
@@ -25,7 +25,7 @@
 
     var assert = chai.assert;
 
-    assert.almostequal = function (a, b, n) {
+    assert.almostEqual = function (a, b, n) {
         n = n || 12;
         return assert.equal(Math.round(a * Math.pow(10, n)) / Math.pow(10, n),
                             Math.round(b * Math.pow(10, n)) / Math.pow(10, n));
@@ -36,7 +36,7 @@
     };
     assert.latLngEqual = function (a, b, n) {
         n = n || 2;
-        return assert.almostequal(a.lat, b.lat, 2) && assert.almostequal(a.lng, b.lng, n);
+        return assert.almostEqual(a.lat, b.lat, 2) && assert.almostEqual(a.lng, b.lng, n);
     }
   </script>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -2,10 +2,11 @@
 <head>
   <meta charset="utf-8">
   <title>Mocha Tests</title>
+  <link rel="stylesheet" href="../node_modules/leaflet/dist/leaflet.css" />
   <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
 </head>
 <body>
-  <div id="map" style="display: none; height: 300px"></div>
+  <div id="map" style="display: none; height: 300px; width: 360px"></div>
   <div id="mocha"></div>
   <script src="../node_modules/chai/chai.js"></script>
   <script src="../node_modules/mocha/mocha.js"></script>
@@ -16,6 +17,9 @@
 
   <script>
     var map = L.map('map').fitWorld();
+    L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+    }).addTo(map);
 
     mocha.setup('bdd');
 

--- a/spec/test.closest.js
+++ b/spec/test.closest.js
@@ -10,8 +10,8 @@ describe('Closest on path with precision', function() {
   it('It should return same point if on path', function(done) {
       var line = L.polyline([[0,0], [1, 1], [2, 2]]);
           closest = L.GeometryUtil.closest(map, line, [1.7, 1.7]);
-      assert.almostequal(closest.lat, 1.7, 2);
-      assert.almostequal(closest.lng, 1.7, 2);
+      assert.almostEqual(closest.lat, 1.7, 2);
+      assert.almostEqual(closest.lng, 1.7, 2);
       done();
   });
 
@@ -20,8 +20,8 @@ describe('Closest on path with precision', function() {
         closest = L.GeometryUtil.closest(map, [[-10, -10], [10, 10]], ll);
     assert.equal(Math.sqrt(2), closest.distance);
     // TODO: should not be almost equal
-    assert.almostequal(closest.lat, 0, 2);
-    assert.almostequal(closest.lng, 0, 2);
+    assert.almostEqual(closest.lat, 0, 2);
+    assert.almostEqual(closest.lng, 0, 2);
     done();
   });
 
@@ -64,8 +64,8 @@ describe('Closest on path with precision', function() {
       var polygon = L.polygon([[0, 0], [10, 10], [0, 10]]),
           ll = [-1, 5],
           closest = L.GeometryUtil.closest(map, polygon, ll);
-      assert.almostequal(closest.lat, 0, 2);
-      assert.almostequal(closest.lng, 5, 2);
+      assert.almostEqual(closest.lat, 0, 2);
+      assert.almostEqual(closest.lng, 5, 2);
       done();
   });
 

--- a/spec/test.closestLayerSnap.js
+++ b/spec/test.closestLayerSnap.js
@@ -33,24 +33,24 @@ describe('Closest snap', function() {
   it('It should not snap to corners if vertices disabled', function(done) {
     var corner = L.GeometryUtil.closestLayerSnap(map, layers, L.latLng([w-d, -w-d]));
     assert.equal(corner.layer, square);
-    assert.almostequal(corner.latlng.lat, w);
-    assert.almostequal(corner.latlng.lng, -w);
+    assert.almostEqual(corner.latlng.lat, w);
+    assert.almostEqual(corner.latlng.lng, -w);
 
     var snap = L.GeometryUtil.closestLayerSnap(map, layers, L.latLng([w-d, -w-d]), Infinity, false);
-    assert.almostequal(snap.latlng.lat, w-d);
-    assert.almostequal(snap.latlng.lng, -w);
+    assert.almostEqual(snap.latlng.lat, w-d);
+    assert.almostEqual(snap.latlng.lng, -w);
     done();
   });
 
   it('It should not snap to corners if distance to vertice exceeds tolerance', function(done) {
     var corner = L.GeometryUtil.closestLayerSnap(map, layers, L.latLng([w-d-d/2, -w-d]));
     assert.equal(corner.layer, square);
-    assert.almostequal(corner.latlng.lat, w);
-    assert.almostequal(corner.latlng.lng, -w);
+    assert.almostEqual(corner.latlng.lat, w);
+    assert.almostEqual(corner.latlng.lng, -w);
 
     var snap = L.GeometryUtil.closestLayerSnap(map, layers, L.latLng([w-d-d/2, -w-d]), d);
-    assert.almostequal(snap.latlng.lat, w-d-d/2);
-    assert.almostequal(snap.latlng.lng, -w);
+    assert.almostEqual(snap.latlng.lat, w-d-d/2);
+    assert.almostEqual(snap.latlng.lng, -w);
     done();
   });
 });

--- a/spec/test.closestSegment.js
+++ b/spec/test.closestSegment.js
@@ -10,8 +10,8 @@ describe('Closest on segment', function() {
     var ll = L.latLng([-1, 1]),
         closest = L.GeometryUtil.closestOnSegment(map, ll, L.latLng([-10, -10]), L.latLng([10, 10]));
     // TODO: should not be almost equal
-    assert.almostequal(0, closest.lat, 2);
-    assert.almostequal(0, closest.lng, 2);
+    assert.almostEqual(0, closest.lat, 2);
+    assert.almostEqual(0, closest.lng, 2);
     done();
   });
 });

--- a/spec/test.locateOnLine.js
+++ b/spec/test.locateOnLine.js
@@ -12,9 +12,9 @@ describe('Locate on line', function() {
   });
 
   it('It should return ratio of point', function(done) {
-    assert.almostequal(0.5, L.GeometryUtil.locateOnLine(map, line, L.latLng([1, 1])), 4);
-    assert.almostequal(0.25, L.GeometryUtil.locateOnLine(map, line, L.latLng([0.5, 0.5])), 4);
-    assert.almostequal(0.85, L.GeometryUtil.locateOnLine(map, line, L.latLng([1.7, 1.7])), 4);
+    assert.almostEqual(0.5, L.GeometryUtil.locateOnLine(map, line, L.latLng([1, 1])), 4);
+    assert.almostEqual(0.25, L.GeometryUtil.locateOnLine(map, line, L.latLng([0.5, 0.5])), 4);
+    assert.almostEqual(0.85, L.GeometryUtil.locateOnLine(map, line, L.latLng([1.7, 1.7])), 4);
     done();
   });
 });


### PR DESCRIPTION
Related to #46 
Add the last segment for nested Polygons.
Doesn't take in consideration the segment defined by first point of polygon A - first point of polygon B 
