### PR TITLE
Allow leaflet dep, 0.7 and up, including 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "generate-docs": "rm -rf docs; node_modules/.bin/jsdoc -c jsdoc.config -d ./docs/"
   },
   "dependencies": {
-    "leaflet": "^0.7.0"
+    "leaflet": ">=0.7.0"
   },
   "devDependencies": {
     "chai": "3.5.0",


### PR DESCRIPTION
The dependency on leaflet was set to `^0.7.0` which doesn't allow to have `1.x.x`.  Moving to `>=0.7.0` allows both 0.7.0 and 1.0.0. 