### PR TITLE
Avoid a deprecated function and fix test

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "license": "BSD-3-Clause",
   "main": "src/leaflet.geometryutil.js",
   "scripts": {
-    "test-leaflet-0.7.7": "npm install leaflet@0.7.7 && node_modules/.bin/mocha-phantomjs spec/index.html",
-    "test-leaflet-1.0.0": "npm install leaflet@1.0.0-rc.3 && node_modules/.bin/mocha-phantomjs spec/index.html",
+    "test-leaflet-0.7.7": "npm install leaflet@0.7.7 --no-save && node_modules/.bin/mocha-phantomjs spec/index.html",
+    "test-leaflet-1.0.0": "npm install leaflet@^1.0.0 --no-save && node_modules/.bin/mocha-phantomjs spec/index.html",
     "test": "npm run test-leaflet-0.7.7 && npm run test-leaflet-1.0.0",
     "generate-docs": "rm -rf docs; node_modules/.bin/jsdoc -c jsdoc.config -d ./docs/"
   },

--- a/spec/index.html
+++ b/spec/index.html
@@ -10,9 +10,7 @@
   <div id="mocha"></div>
   <script src="../node_modules/chai/chai.js"></script>
   <script src="../node_modules/mocha/mocha.js"></script>
-  <script src="../node_modules/leaflet/build/deps.js"></script>
-  <script src="../node_modules/leaflet/debug/leaflet-include.js"></script>
-  <!-- <script src="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.js"></script> -->
+  <script src="../node_modules/leaflet/dist/leaflet.js"></script>
   <script src="../src/leaflet.geometryutil.js"></script>
 
   <script>

--- a/src/leaflet.geometryutil.js
+++ b/src/leaflet.geometryutil.js
@@ -17,7 +17,7 @@
 }(function (L) {
 "use strict";
 
-L.Polyline._flat = L.Polyline._flat || function (latlngs) {
+L.Polyline._flat = L.LineUtil.isFlat || L.Polyline._flat || function (latlngs) {
     // true if it's a flat array of latlngs; false if nested
     return !L.Util.isArray(latlngs[0]) || (typeof latlngs[0][0] !== 'object' && typeof latlngs[0][0] !== 'undefined');
 };


### PR DESCRIPTION
This PR will include the following updates
* use version range in `test-leaflet-1.0.0` to ensure the library is tested with the latest leaflet and use `--no-save` to ensure the `package.json` is unchanged by npm5 during testing.
* ensure the leaflet path in `spec/index.html` works in both 0.7.x and 1.x (current one doesn't work in 1.2)
* fix #68 