### PR TITLE
Fix problem of narrow angles locateOnLine 

### DIFF
--- a/spec/test.locateOnLine.js
+++ b/spec/test.locateOnLine.js
@@ -1,5 +1,6 @@
 describe('Locate on line', function() {
   var line = L.polyline([[0,0], [1, 1], [2, 2]]);
+  var line_narrow_angle = L.polyline([[0,0], [0, 40], [9, 0]])
 
   it('It should return 0 if start', function(done) {
     assert.equal(0, L.GeometryUtil.locateOnLine(map, line, L.latLng([0, 0])));
@@ -15,6 +16,12 @@ describe('Locate on line', function() {
     assert.almostEqual(0.5, L.GeometryUtil.locateOnLine(map, line, L.latLng([1, 1])), 4);
     assert.almostEqual(0.25, L.GeometryUtil.locateOnLine(map, line, L.latLng([0.5, 0.5])), 4);
     assert.almostEqual(0.85, L.GeometryUtil.locateOnLine(map, line, L.latLng([1.7, 1.7])), 4);
+    done();
+  });
+
+  it('It should return ratio of point', function(done) {
+    assert.almostEqual(0.433, L.GeometryUtil.locateOnLine(map, line_narrow_angle, L.latLng([0, 35])), 4);
+    assert.almostEqual(0.559, L.GeometryUtil.locateOnLine(map, line_narrow_angle, L.latLng([1.5, 35])), 3);
     done();
   });
 });

--- a/src/leaflet.geometryutil.js
+++ b/src/leaflet.geometryutil.js
@@ -540,7 +540,7 @@ L.GeometryUtil = L.extend(L.GeometryUtil || {}, {
             var l1 = latlngs[i],
                 l2 = latlngs[i+1];
             portion = lengths[i];
-            if (L.GeometryUtil.belongsSegment(point, l1, l2)) {
+            if (L.GeometryUtil.belongsSegment(point, l1, l2, 0.0001)) {
                 portion += l1.distanceTo(point);
                 found = true;
                 break;


### PR DESCRIPTION
Hello,

This pull request is link with : #32 

1 : without 
![capture d ecran de 2019-01-31 17-27-08](https://user-images.githubusercontent.com/26329336/52070735-ce14f680-2581-11e9-9f1d-b3e266881615.png)

2 : with 
![capture d ecran de 2019-01-31 17-28-06](https://user-images.githubusercontent.com/26329336/52070765-dd943f80-2581-11e9-9625-3b9eedae1653.png)

The problem come from that when a subline is really long, the value delta/hypotenuse will be smaller than tolerance from belongsSegment for much more lines. In the example above, the point is linked with multiple sublines on the same line. But without a tolerance we will get only a random subline and then get the wrong locateOnLine value (linked with the wrong subline).