### PR TITLE
Fixes a crash if a multilinestring has an element with only one vertex (fixes #84)

### DIFF
--- a/src/leaflet.geometryutil.js
+++ b/src/leaflet.geometryutil.js
@@ -184,7 +184,7 @@ L.GeometryUtil = L.extend(L.GeometryUtil || {}, {
                 // recursive
                 for (i = 0; i < layer.length; i++) {
                     subResult = L.GeometryUtil.closest(map, layer[i], latlng, vertices);
-                    if (subResult.distance < mindist) {
+                    if (subResult && subResult.distance < mindist) {
                         mindist = subResult.distance;
                         result = subResult;
                     }


### PR DESCRIPTION
Fixes a crash if a multilinestring has an element with only one vertex