### PR TITLE
higher precision meter values

### DIFF
--- a/spec/test.readableDistance.js
+++ b/spec/test.readableDistance.js
@@ -1,11 +1,11 @@
 describe('Readable distances', function() {
   it('It should be meters by default', function(done) {
-    assert.equal("0 m", L.GeometryUtil.readableDistance(0));
+    assert.equal("0.0 m", L.GeometryUtil.readableDistance(0));
     done();
   });
 
-  it('It should be 0 yd if imperial', function(done) {
-    assert.equal("0 yd", L.GeometryUtil.readableDistance(0, 'imperial'));
+  it('It should be 0.0 yd if imperial', function(done) {
+    assert.equal("0.0 yd", L.GeometryUtil.readableDistance(0, 'imperial'));
     done();
   });
 

--- a/src/leaflet.geometryutil.js
+++ b/src/leaflet.geometryutil.js
@@ -73,7 +73,7 @@ L.GeometryUtil = L.extend(L.GeometryUtil || {}, {
                 distanceStr = (distance  / 1000).toFixed(2) + ' km';
             }
             else {
-                distanceStr = distance.toFixed(2) + ' m';
+                distanceStr = distance.toFixed(1) + ' m';
             }
         }
         else {
@@ -82,7 +82,7 @@ L.GeometryUtil = L.extend(L.GeometryUtil || {}, {
                 distanceStr = (distance / 1760).toFixed(2) + ' miles';
             }
             else {
-                distanceStr = distance.toFixed(2) + ' yd';
+                distanceStr = distance.toFixed(1) + ' yd';
             }
         }
         return distanceStr;

--- a/src/leaflet.geometryutil.js
+++ b/src/leaflet.geometryutil.js
@@ -73,7 +73,7 @@ L.GeometryUtil = L.extend(L.GeometryUtil || {}, {
                 distanceStr = (distance  / 1000).toFixed(2) + ' km';
             }
             else {
-                distanceStr = Math.ceil(distance) + ' m';
+                distanceStr = distance.toFixed(2) + ' m';
             }
         }
         else {
@@ -82,7 +82,7 @@ L.GeometryUtil = L.extend(L.GeometryUtil || {}, {
                 distanceStr = (distance / 1760).toFixed(2) + ' miles';
             }
             else {
-                distanceStr = Math.ceil(distance) + ' yd';
+                distanceStr = distance.toFixed(2) + ' yd';
             }
         }
         return distanceStr;


### PR DESCRIPTION
I changed the rounding of values smaller than 1.000 in `readableDistance()` to also round to fixed 2 points for both imperial and metric system to increase the precision when zoomed in really far.