### PR TITLE
fix "has no default export" error in typescript definition

### DIFF
--- a/src/leaflet.geometryutil.d.ts
+++ b/src/leaflet.geometryutil.d.ts
@@ -1,4 +1,5 @@
-import L, { LatLngLiteral, Layer } from "leaflet";
+import * as L from "leaflet";
+import { LatLngLiteral, Layer } from "leaflet";
 
 interface LayerPointRelation<LayerType extends Layer = Layer> {
     layer: LayerType;


### PR DESCRIPTION
I updated the import statements in the typescript definition file in order to fix the issue described in https://github.com/makinacorpus/Leaflet.GeometryUtil/pull/91#issuecomment-839548987