### PR TITLE
Changed imports to acommodate to new ngx-leaflet organization

### DIFF
--- a/src/leaflet.geometryutil.d.ts
+++ b/src/leaflet.geometryutil.d.ts
@@ -1,4 +1,5 @@
-import L, { LatLngLiteral, Layer } from "leaflet";
+import * as L from "leaflet";
+import { LatLngLiteral, Layer } from "leaflet"
 
 interface LayerPointRelation<LayerType extends Layer = Layer> {
     layer: LayerType;


### PR DESCRIPTION
Whenever you try to import the module into an Angular project using Leaflet through the [ngx-leaflet](https://github.com/bluehalo/ngx-leaflet) package you get the following warning

```
Error: node_modules/leaflet-geometryutil/src/leaflet.geometryutil.d.ts:1:8 - error TS1192: Module '"/home/god/Drongo/Drongo/WebApp_2.0/node_modules/@types/leaflet/index"' has no default export.

1 import L, { LatLngLiteral, Layer } from "leaflet";
```

The modification of the lines performed in this commit makes the error disappear.
Thank you, beforehand